### PR TITLE
Fix: Restore broken project pages and OAuth session persistence

### DIFF
--- a/src/pages/api/auth/callback.ts
+++ b/src/pages/api/auth/callback.ts
@@ -88,32 +88,10 @@ export const GET: APIRoute = async ({ url, redirect, cookies }) => {
     }
 
     console.log('✅ Session created successfully')
+    console.log('✅ Session cookies automatically set by SDK, redirecting...')
 
-    // Manually set session cookies
-    if (data.session) {
-      const maxAge = 100000000 // ~3 years
-      const cookieOptions = `Path=/; Domain=${cookieDomain}; Max-Age=${maxAge}; SameSite=Lax; Secure; HttpOnly`
-
-      // Set access token
-      cookies.set(`sb-${supabaseUrl.split('//')[1].split('.')[0]}-auth-token`, JSON.stringify({
-        access_token: data.session.access_token,
-        refresh_token: data.session.refresh_token,
-        expires_at: data.session.expires_at,
-        expires_in: data.session.expires_in,
-        token_type: data.session.token_type,
-        user: data.session.user
-      }), {
-        path: '/',
-        domain: cookieDomain,
-        maxAge,
-        sameSite: 'lax',
-        secure: true,
-        httpOnly: false // Must be false for Supabase client to read
-      })
-
-      console.log('✅ Cookies set, redirecting...')
-    }
-
+    // Session cookies are automatically set by the createServerClient cookie handlers
+    // No need to manually set cookies - the SDK handles this correctly
     return redirect(next, 303)
   } catch (error) {
     return new Response(JSON.stringify({

--- a/src/pages/projects/[id].astro
+++ b/src/pages/projects/[id].astro
@@ -1,5 +1,5 @@
 ---
-export const prerender = false; // Auth UI requires server rendering
+export const prerender = true; // Enable static pre-rendering for project pages
 
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import StatusBadge from '../../components/StatusBadge.astro';


### PR DESCRIPTION
## Summary

This PR fixes two critical bugs introduced in recent commits:

1. **Project detail pages returning 500 errors** - All project pages at `/projects/*` were broken
2. **OAuth sign-in appearing to fail** - Google OAuth completed successfully but session wasn't detected, causing "Sign in with Google" button to remain visible

## Root Causes

### Issue 1: Project Pages Breaking (commit eeb828d)
- Commit `eeb828d` disabled prerendering on pages with auth UI
- Accidentally changed `prerender = false` on `src/pages/projects/[id].astro`
- This page uses `getStaticPaths()` which requires `prerender = true`
- Result: `project` prop undefined → 500 errors on all project pages

### Issue 2: OAuth Session Not Persisting (commit 86a390f)
- Commit `86a390f` added manual cookie setting to `/api/auth/callback`
- Manual cookies used incorrect naming convention
- Overrode Supabase SDK's automatic cookie handling
- Result: Middleware couldn't find session → users appeared signed out after successful OAuth

## Changes Made

### 1. Restore Project Page Prerendering (`src/pages/projects/[id].astro`)
```diff
- export const prerender = false; // Auth UI requires server rendering
+ export const prerender = true; // Enable static pre-rendering for project pages
```

**Why**: Project detail pages are public content and don't need server-side auth. They use `getStaticPaths()` to generate 8 static HTML pages at build time.

### 2. Remove Manual Cookie Setting (`src/pages/api/auth/callback.ts`)
- Removed 24 lines of manual cookie manipulation (lines 92-115)
- Let `createServerClient` cookie handlers manage cookies automatically
- SDK sets cookies with correct naming when `exchangeCodeForSession()` is called

**Why**: The Supabase SDK already has proper cookie handlers configured. Manual override was breaking session detection.

## Testing Completed

### ✅ All Project Pages Working
```
✓ /projects/ai-trading-system: 200 OK
✓ /projects/data-visualization-platform: 200 OK  
✓ /projects/neural-network-framework: 200 OK
✓ /projects/blockchain-analytics: 200 OK
(+ 4 more pages)
```

### ✅ Main Pages Working
```
✓ homepage (/): 200 OK
✓ about (/about): 200 OK
✓ work (/work): 200 OK
```

### ✅ Auth Endpoints Working
```
✓ POST /api/auth/signin: Returns OAuth URL
✓ GET /api/auth/callback: Proper error handling
✓ Sign in button renders in nav menu
```

### ✅ Production Build Succeeds
```
✓ Build completed successfully (1.82s)
✓ All 8 project pages pre-rendered
✓ Server entrypoints built
```

### ✅ Unit Tests Passing
```
✓ 19 tests passed (19)
✓ auth.test.ts: 11 tests passed
✓ subscription.test.ts: 8 tests passed
```

## Expected Behavior After Merge

1. **Project pages load correctly** - No more 500 errors
2. **OAuth sign-in works end-to-end**:
   - Click "Sign in with Google"
   - Complete Google OAuth
   - Redirect back to site
   - **User profile appears in nav** (instead of "Sign in" button)
   - Session persists across page refreshes
   - Session persists across navigation

## Notes

- Auth session warnings during build are expected (no session exists at build time)
- Other pages (/, /about, /work) remain server-rendered for auth UI
- Zero regression - all existing functionality preserved

## Commits

- `cd9fa13` - fix: restore prerendering for project detail pages
- `625f69c` - fix: remove manual cookie setting that breaks session persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>